### PR TITLE
fixes for pkgdown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -110,3 +110,4 @@ BugReports: https://github.com/ropensci/ReLTER/issues
 Config/testthat/edition: 3
 RoxygenNote: 7.1.2
 Language: en-GB
+Roxygen: list(markdown = TRUE)

--- a/R/get_activity_info.R
+++ b/R/get_activity_info.R
@@ -27,8 +27,7 @@
 #' activities
 #'
 #' @section The function output:
-#' \figure{get_activity_info_fig.png}{Map of "Study of non-indigenous (alien)
-#' species in the Mar Piccolo of Taranto" activity}
+#' \figure{get_activity_info_fig.png}{Map of "Study of non-indigenous (alien) species in the Mar Piccolo of Taranto" activity}
 #'
 ### function get_activity_info
 get_activity_info <- function(activityid, show_map = FALSE) {

--- a/R/get_dataset_info.R
+++ b/R/get_dataset_info.R
@@ -29,8 +29,7 @@
 #' tDataset
 #'
 #' @section The function output:
-#' \figure{get_dataset_info_fig.png}{Map of "LTER Northern Adriatic Sea
-#' (Italy) marine data from 1965 to 2015" dataset}
+#' \figure{get_dataset_info_fig.png}{Map of "LTER Northern Adriatic Sea (Italy) marine data from 1965 to 2015" dataset}
 #'
 ### function get_dataset_info
 get_dataset_info <- function(datasetid, show_map = FALSE) {


### PR DESCRIPTION
@oggioniale The docs website for ReLTER can't be built yet cf https://ropensci.r-universe.dev/ui#builds Here are the fixes

- I added the Markdown use to description via `usethis::use_roxygen_md()` (actually not causing the bug but without this field the Markdown code tags aren't translated to `\code` in the Rd)
- I collapsed the roxygen2 figure tags to one line. This is a workaround for a pkgdown bug https://github.com/r-lib/pkgdown/issues/2080

Please run `document()`.

On another note, you can remove the docs/ folder as the pkgdown website will be built by the rOpenSci docs server (once we solve the above issues).

Happy to answer any question!